### PR TITLE
Add entities

### DIFF
--- a/.github/workflows/check_jupyterbook.yml
+++ b/.github/workflows/check_jupyterbook.yml
@@ -2,7 +2,7 @@ name: Test that Jupyter-Book builds
 on: [push, pull_request]
 jobs:
   build:
-    if: github.repository == 'nikhilwoodruff/openfisca-us'
+    if: github.repository == 'ubicenter/openfisca-us'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/deploy_jupyterbook.yml
+++ b/.github/workflows/deploy_jupyterbook.yml
@@ -5,7 +5,7 @@ on:
       - master
 jobs:
   build-and-deploy:
-    if: github.repository == 'nikhilwoodruff/openfisca-us'
+    if: github.repository == 'ubicenter/openfisca-us'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -1,44 +1,4 @@
-all: test
-
-uninstall:
-	pip freeze | grep -v "^-e" | xargs pip uninstall -y
-
-clean:
-	rm -rf build dist
-	find . -name '*.pyc' -exec rm \{\} \;
-
-deps:
-	pip install --upgrade pip twine wheel
-
-install: deps
-	@# Install OpenFisca-Extension-Template for development.
-	@# `make install` installs the editable version of OpenFisca-France.
-	@# This allows contributors to test as they code.
-	pip install -e '.[dev]' --upgrade --use-deprecated=legacy-resolver
-
-build: clean deps
-	@# Install OpenFisca-Extension-Template for deployment and publishing.
-	@# `make build` allows us to be be sure tests are run against the packaged version
-	@# of OpenFisca-Extension-Template, the same we put in the hands of users and reusers.
-	python setup.py bdist_wheel
-	find dist -name "*.whl" -exec pip install --force-reinstall {}[dev] \;
-
-check-syntax-errors:
-	python -m compileall -q .
-
-format-style:
-	@# Do not analyse .gitignored files.
-	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
-	autopep8 `git ls-files | grep "\.py$$"`
-
-check-style:
-	@# Do not analyse .gitignored files.
-	@# `make` needs `$$` to output `$`. Ref: http://stackoverflow.com/questions/2382764.
-	flake8 `git ls-files | grep "\.py$$"`
-	pylint `git ls-files | grep "\.py$$"`
-
-test: clean check-syntax-errors check-style
-	openfisca test --country-package openfisca_us openfisca_us/tests
-
-serve-local: build
-	openfisca serve --country-package openfisca_us
+format:
+	black . -l 79
+test: format
+	openfisca test -c openfisca_us openfisca_us/tests/baseline

--- a/openfisca_us/api/microsimulation.py
+++ b/openfisca_us/api/microsimulation.py
@@ -2,6 +2,7 @@ from microdf.generic import MicroDataFrame
 import numpy as np
 from openfisca_core import periods
 from openfisca_core.model_api import *
+from openfisca_data.datasets.us.cps.raw_cps import RawCPS
 import openfisca_us
 import pandas as pd
 from openfisca_core.simulation_builder import SimulationBuilder
@@ -31,6 +32,10 @@ class Microsimulation:
                 self.system = reform(self.system)
 
     def load_cps(self, year):
+        if year not in BaseCPS.years:
+            if year not in RawCPS.years:
+                RawCPS.generate(year)
+            BaseCPS.generate(year)
         self.system = openfisca_us.CountryTaxBenefitSystem()
         self.apply_reforms(
             (BaseCPS.input_reform_from_year(year), self.reforms)

--- a/openfisca_us/api/microsimulation.py
+++ b/openfisca_us/api/microsimulation.py
@@ -32,7 +32,9 @@ class Microsimulation:
 
     def load_cps(self, year):
         self.system = openfisca_us.CountryTaxBenefitSystem()
-        self.apply_reforms(self.reforms)
+        self.apply_reforms(
+            (BaseCPS.input_reform_from_year(year), self.reforms)
+        )
         builder = SimulationBuilder()
         builder.create_entities(self.system)
 

--- a/openfisca_us/api/microsimulation.py
+++ b/openfisca_us/api/microsimulation.py
@@ -40,7 +40,7 @@ class Microsimulation:
 
         builder.declare_person_entity("person", base_cps[f"person_id/{year}"])
 
-        for group_entity in ("family", "taxunit", "household"):
+        for group_entity in ("tax_unit", "family", "spm_unit", "household"):
             primary_keys = np.array(base_cps[f"{group_entity}_id/{year}"])
             group = builder.declare_entity(group_entity, primary_keys)
             foreign_keys = np.array(

--- a/openfisca_us/entities.py
+++ b/openfisca_us/entities.py
@@ -1,17 +1,9 @@
-"""
-This file defines the entities needed by our legislation.
-
-Taxes and benefits can be calculated for different entities: persons, household, companies, etc.
-
-See https://openfisca.org/doc/key-concepts/person,_entities,_role.html
-"""
-
 from openfisca_core.entities import build_entity
 
 TaxUnit = build_entity(
-    key="taxunit",
-    plural="taxunits",
-    label="Tax Unit",
+    key="tax_unit",
+    plural="tax_units",
+    label="Tax unit",
     doc="""
     A tax unit.
     """,
@@ -56,6 +48,22 @@ Family = build_entity(
     ],
 )
 
+SPMUnit = build_entity(
+    key="spm_unit",
+    plural="spm_units",
+    label="SPM unit",
+    doc="""
+    An SPM unit.
+    """,
+    roles=[
+        dict(
+            key="member",
+            label="Member",
+            doc="A member of the group",
+        ),
+    ],
+)
+
 Person = build_entity(
     key="person",
     plural="people",
@@ -66,4 +74,4 @@ Person = build_entity(
     is_person=True,
 )
 
-entities = [Household, TaxUnit, Family, Person]
+entities = [Household, SPMUnit, Family, TaxUnit, Person]

--- a/openfisca_us/entities.py
+++ b/openfisca_us/entities.py
@@ -16,17 +16,10 @@ TaxUnit = build_entity(
     A tax unit.
     """,
     roles=[
-        dict(key="head", label="Head", max=1, doc="The head filer"),
         dict(
-            key="spouse",
-            label="Spouse",
-            max=1,
-            doc="The spouse if joint filing",
-        ),
-        dict(
-            key="dependent",
-            label="Dependent",
-            doc="Dependents in the tax unit",
+            key="member",
+            label="Member",
+            doc="A member of the group",
         ),
     ],
 )
@@ -40,15 +33,9 @@ Household = build_entity(
     """,
     roles=[
         dict(
-            key="head",
-            label="Head",
-            max=1,
-            doc="The reference person for the household",
-        ),
-        dict(
-            key="non_head",
-            label="Non-head",
-            doc="Any person other than the head-of-household",
+            key="member",
+            label="Member",
+            doc="A member of the group",
         ),
     ],
 )
@@ -62,21 +49,9 @@ Family = build_entity(
     """,
     roles=[
         dict(
-            key="head",
-            label="Head",
-            max=1,
-            doc="The reference person for the family",
-        ),
-        dict(
-            key="spouse",
-            label="Spouse",
-            max=1,
-            doc="The spouse if joint filing",
-        ),
-        dict(
-            key="dependent",
-            label="Dependent",
-            doc="Dependents in the tax unit",
+            key="member",
+            label="Member",
+            doc="A member of the group",
         ),
     ],
 )

--- a/openfisca_us/entities.py
+++ b/openfisca_us/entities.py
@@ -11,9 +11,9 @@ from openfisca_core.entities import build_entity
 TaxUnit = build_entity(
     key="taxunit",
     plural="taxunits",
-    label="The tax unit",
+    label="Tax Unit",
     doc="""
-    Description of a tax unit
+    A tax unit.
     """,
     roles=[
         dict(key="head", label="Head", max=1, doc="The head filer"),
@@ -31,14 +31,64 @@ TaxUnit = build_entity(
     ],
 )
 
+Household = build_entity(
+    key="household",
+    plural="households",
+    label="Household",
+    doc="""
+    A household.
+    """,
+    roles=[
+        dict(
+            key="head",
+            label="Head",
+            max=1,
+            doc="The reference person for the household",
+        ),
+        dict(
+            key="non_head",
+            label="Non-head",
+            doc="Any person other than the head-of-household",
+        ),
+    ],
+)
+
+Family = build_entity(
+    key="family",
+    plural="families",
+    label="Family",
+    doc="""
+    A family.
+    """,
+    roles=[
+        dict(
+            key="head",
+            label="Head",
+            max=1,
+            doc="The reference person for the family",
+        ),
+        dict(
+            key="spouse",
+            label="Spouse",
+            max=1,
+            doc="The spouse if joint filing",
+        ),
+        dict(
+            key="dependent",
+            label="Dependent",
+            doc="Dependents in the tax unit",
+        ),
+    ],
+)
+
 Person = build_entity(
     key="person",
     plural="people",
-    label="An individual person",
+    label="Person",
     doc="""
-    Description of a person
+    A person.
     """,
     is_person=True,
 )
 
-entities = [TaxUnit, Person]
+entities = [Household, TaxUnit, Family, Person]

--- a/openfisca_us/entities.py
+++ b/openfisca_us/entities.py
@@ -11,7 +11,7 @@ TaxUnit = build_entity(
         dict(
             key="member",
             label="Member",
-            doc="A member of the group",
+            doc="A member of the tax unit",
         ),
     ],
 )
@@ -27,7 +27,7 @@ Household = build_entity(
         dict(
             key="member",
             label="Member",
-            doc="A member of the group",
+            doc="A member of the household",
         ),
     ],
 )
@@ -43,7 +43,7 @@ Family = build_entity(
         dict(
             key="member",
             label="Member",
-            doc="A member of the group",
+            doc="A member of the family",
         ),
     ],
 )
@@ -59,7 +59,7 @@ SPMUnit = build_entity(
         dict(
             key="member",
             label="Member",
-            doc="A member of the group",
+            doc="A member of the SPM unit",
         ),
     ],
 )

--- a/openfisca_us/variables/entity/family.py
+++ b/openfisca_us/variables/entity/family.py
@@ -9,6 +9,13 @@ class family_id(Variable):
     definition_period = ETERNITY
 
 
+class family_weight(Variable):
+    value_type = float
+    entity = Family
+    label = u"Family weight"
+    definition_period = YEAR
+
+
 class person_family_id(Variable):
     value_type = int
     entity = Person

--- a/openfisca_us/variables/entity/family.py
+++ b/openfisca_us/variables/entity/family.py
@@ -1,0 +1,14 @@
+from openfisca_core.model_api import *
+from openfisca_us.entities import *
+
+class family_id(Variable):
+    value_type = float
+    entity = Family
+    label = u"Unique reference for this family"
+    definition_period = ETERNITY
+
+class person_family_id(Variable):
+    value_type = int
+    entity = Person
+    label = u"Unique reference for the family of this person"
+    definition_period = ETERNITY

--- a/openfisca_us/variables/entity/household.py
+++ b/openfisca_us/variables/entity/household.py
@@ -9,6 +9,13 @@ class household_id(Variable):
     definition_period = ETERNITY
 
 
+class household_weight(Variable):
+    value_type = float
+    entity = Household
+    label = u"Household weight"
+    definition_period = YEAR
+
+
 class person_household_id(Variable):
     value_type = int
     entity = Person

--- a/openfisca_us/variables/entity/household.py
+++ b/openfisca_us/variables/entity/household.py
@@ -2,15 +2,15 @@ from openfisca_core.model_api import *
 from openfisca_us.entities import *
 
 
-class family_id(Variable):
+class household_id(Variable):
     value_type = float
-    entity = Family
-    label = u"Unique reference for this family"
+    entity = Household
+    label = u"Unique reference for this household"
     definition_period = ETERNITY
 
 
-class person_family_id(Variable):
+class person_household_id(Variable):
     value_type = int
     entity = Person
-    label = u"Unique reference for the family of this person"
+    label = u"Unique reference for the household of this person"
     definition_period = ETERNITY

--- a/openfisca_us/variables/entity/person.py
+++ b/openfisca_us/variables/entity/person.py
@@ -9,8 +9,15 @@ class P_person_id(Variable):
     definition_period = ETERNITY
 
 
+class person_weight(Variable):
+    value_type = float
+    entity = Person
+    label = u"Person weight"
+    definition_period = YEAR
+
+
 class age(Variable):
     value_type = int
     entity = Person
-    label = u"Age of the person in years"
+    label = u"Age"
     definition_period = YEAR

--- a/openfisca_us/variables/entity/person.py
+++ b/openfisca_us/variables/entity/person.py
@@ -2,6 +2,13 @@ from openfisca_core.model_api import *
 from openfisca_us.entities import *
 
 
+class P_person_id(Variable):
+    value_type = int
+    entity = Person
+    label = u"Unique reference for this person"
+    definition_period = ETERNITY
+
+
 class age(Variable):
     value_type = int
     entity = Person

--- a/openfisca_us/variables/entity/person.py
+++ b/openfisca_us/variables/entity/person.py
@@ -2,7 +2,7 @@ from openfisca_core.model_api import *
 from openfisca_us.entities import *
 
 
-class P_person_id(Variable):
+class person_id(Variable):
     value_type = int
     entity = Person
     label = u"Unique reference for this person"

--- a/openfisca_us/variables/entity/spm_unit.py
+++ b/openfisca_us/variables/entity/spm_unit.py
@@ -1,0 +1,23 @@
+from openfisca_core.model_api import *
+from openfisca_us.entities import *
+
+
+class spm_unit_id(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = u"Unique reference for this SPM unit"
+    definition_period = ETERNITY
+
+
+class spm_unit_weight(Variable):
+    value_type = float
+    entity = SPMUnit
+    label = u"SPM unit weight"
+    definition_period = YEAR
+
+
+class person_spm_unit_id(Variable):
+    value_type = int
+    entity = Person
+    label = u"Unique reference for the SPM unit of this person"
+    definition_period = ETERNITY

--- a/openfisca_us/variables/entity/taxunit.py
+++ b/openfisca_us/variables/entity/taxunit.py
@@ -2,6 +2,20 @@ from openfisca_core.model_api import *
 from openfisca_us.entities import *
 
 
+class taxunit_id(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = u"Unique reference for this tax unit"
+    definition_period = ETERNITY
+
+
+class person_taxunit_id(Variable):
+    value_type = int
+    entity = Person
+    label = u"Unique reference for the tax unit of this person"
+    definition_period = ETERNITY
+
+
 class MARSType(Enum):
     SINGLE = "Single"
     JOINT = "Joint"

--- a/openfisca_us/variables/entity/taxunit.py
+++ b/openfisca_us/variables/entity/taxunit.py
@@ -9,6 +9,13 @@ class taxunit_id(Variable):
     definition_period = ETERNITY
 
 
+class taxunit_weight(Variable):
+    value_type = float
+    entity = TaxUnit
+    label = u"Tax unit weight"
+    definition_period = YEAR
+
+
 class person_taxunit_id(Variable):
     value_type = int
     entity = Person

--- a/openfisca_us/variables/entity/taxunit.py
+++ b/openfisca_us/variables/entity/taxunit.py
@@ -2,21 +2,21 @@ from openfisca_core.model_api import *
 from openfisca_us.entities import *
 
 
-class taxunit_id(Variable):
+class tax_unit_id(Variable):
     value_type = float
     entity = TaxUnit
     label = u"Unique reference for this tax unit"
     definition_period = ETERNITY
 
 
-class taxunit_weight(Variable):
+class tax_unit_weight(Variable):
     value_type = float
     entity = TaxUnit
     label = u"Tax unit weight"
     definition_period = YEAR
 
 
-class person_taxunit_id(Variable):
+class person_tax_unit_id(Variable):
     value_type = int
     entity = Person
     label = u"Unique reference for the tax unit of this person"

--- a/setup.py
+++ b/setup.py
@@ -29,11 +29,12 @@ setup(
         ),
     ],
     install_requires=[
-        "OpenFisca-Core[web-api] >= 35.0.0, < 36.0.0",
+        "OpenFisca-Core[web-api] >= 35.0.0",
         "openfisca_data @ git+https://github.com/ubicenter/openfisca-data",
         "microdf @ git+https://github.com/PSLmodels/microdf",
         "pandas",
         "tqdm",
+        "requests",
     ],
     extras_require={
         "dev": [

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     ],
     install_requires=[
         "OpenFisca-Core[web-api] >= 35.0.0, < 36.0.0",
+        "openfisca_data @ git+https://github.com/ubicenter/openfisca-data",
         "microdf @ git+https://github.com/PSLmodels/microdf",
         "pandas",
         "tqdm",


### PR DESCRIPTION
This adds the person, tax unit, family, SPM unit and household entities, and switches to using the `BaseCPS` dataset in `openfisca-data` (relevant [PR](https://github.com/UBICenter/openfisca-data/pull/1)).