### PR TITLE
Various fixes for tax-benefit.org compatibility

### DIFF
--- a/openfisca_us/__init__.py
+++ b/openfisca_us/__init__.py
@@ -22,6 +22,8 @@ COUNTRY_DIR = os.path.dirname(os.path.abspath(__file__))
 # Our country tax and benefit class inherits from the general TaxBenefitSystem class.
 # The name CountryTaxBenefitSystem must not be changed, as all tools of the OpenFisca ecosystem expect a CountryTaxBenefitSystem class to be exposed in the __init__ module of a country package.
 class CountryTaxBenefitSystem(TaxBenefitSystem):
+    CURRENCY = '$'
+
     def __init__(self):
         # We initialize our tax and benefit system with the general constructor
         super().__init__(entities.entities)

--- a/openfisca_us/parameters/tax/deductions/itemized/charity/nonitemizers_max.yaml
+++ b/openfisca_us/parameters/tax/deductions/itemized/charity/nonitemizers_max.yaml
@@ -4,4 +4,4 @@ values:
   2020-01-01: 300
   2021-01-01: 0
 metadata:
-  unit: USD
+  unit: currency-USD

--- a/openfisca_us/parameters/tax/deductions/standard/aged_or_blind/age_threshold.yaml
+++ b/openfisca_us/parameters/tax/deductions/standard/aged_or_blind/age_threshold.yaml
@@ -3,4 +3,4 @@ values:
   0001-01-01:
     value: 65
 metadata:
-  unit: years
+  unit: year

--- a/openfisca_us/parameters/tax/deductions/standard/aged_or_blind/age_threshold.yaml
+++ b/openfisca_us/parameters/tax/deductions/standard/aged_or_blind/age_threshold.yaml
@@ -1,6 +1,6 @@
 description: Age at which a person qualifies for the aged standard deduction addition
 values:
-  0000-01-01:
+  0001-01-01:
     value: 65
 metadata:
   unit: years

--- a/openfisca_us/parameters/tax/deductions/standard/aged_or_blind/amount.yaml
+++ b/openfisca_us/parameters/tax/deductions/standard/aged_or_blind/amount.yaml
@@ -20,4 +20,4 @@ WIDOW:
     2018-01-01: 1300
     2019-01-01: 1300
 metadata:
-  unit: USD
+  unit: currency-USD

--- a/openfisca_us/parameters/tax/deductions/standard/amount.yaml
+++ b/openfisca_us/parameters/tax/deductions/standard/amount.yaml
@@ -20,4 +20,4 @@ WIDOW:
     2018-01-01: 24000
     2019-01-01: 24400
 metadata:
-  unit: USD
+  unit: currency-USD

--- a/openfisca_us/parameters/tax/deductions/standard/dependent/additional_earned_income.yaml
+++ b/openfisca_us/parameters/tax/deductions/standard/dependent/additional_earned_income.yaml
@@ -2,4 +2,4 @@ description: Addition to earned income for the standard deduction if claimed as 
 values: 
   0000-01-01: 350
 metadata:
-  unit: USD
+  unit: currency-USD

--- a/openfisca_us/parameters/tax/deductions/standard/dependent/additional_earned_income.yaml
+++ b/openfisca_us/parameters/tax/deductions/standard/dependent/additional_earned_income.yaml
@@ -1,5 +1,5 @@
 description: Addition to earned income for the standard deduction if claimed as a dependent
 values: 
-  0000-01-01: 350
+  0001-01-01: 350
 metadata:
   unit: currency-USD

--- a/openfisca_us/parameters/tax/deductions/standard/dependent/amount.yaml
+++ b/openfisca_us/parameters/tax/deductions/standard/dependent/amount.yaml
@@ -3,4 +3,4 @@ values:
   2018-01-01: 1050
   2019-01-01: 1100
 metadata:
-  unit: USD
+  unit: currency-USD

--- a/openfisca_us/variables/finance/tax/outputs.py
+++ b/openfisca_us/variables/finance/tax/outputs.py
@@ -97,7 +97,7 @@ class sey_s(Variable):
     definition_period = YEAR
 
     def formula(tax_unit, period, parameters):
-        return add(tax_unit, period, "e00900s", "e02100ps", "k1bx14s")
+        return add(tax_unit, period, "e00900s", "e02100s", "k1bx14s")
 
 
 class sey(Variable):


### PR DESCRIPTION
* Minor change.
* Impacted periods: all.
* Impacted areas: `openfisca_us`
* Details:
  - Add CURRENCY class variable to tax benefit system
  - Rename USD unit to currency-USD
  - Replace 0000-01-01 date with 0001-01-01
  - Rename years unit to year
  - Fix typo in e02100s variable name 
